### PR TITLE
Added additional steps for "Build from source"

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,11 @@ Web UI will be available at `http://localhost:8000`
 ```
     git clone https://github.com/Landoop/kafka-connect-ui.git
     cd kafka-connect-ui
+    npm install -g bower
+    npm install -g http-server
     npm install
-    http-server .
+    bower install
+    http-server -p 8080 .
 ```
 Web UI will be available at `http://localhost:8080`
 


### PR DESCRIPTION
Since http-server and bower are necessary dependencies I suggest adding `npm install -g http-server` and `npm install -g bower`. Without running `bower install` the `bower_components/` directory never gets created and end up with a bunch of 404s when navigating to the page. After running `bower install` in the root of `kafka-topics-ui/` all the necessary dependencies get added to the `bower_components` directory. I also added `-p 8080` to http-server as a breadcrumb for the end-user to let them know that is how you can specify which port to run on.